### PR TITLE
Replaced getOpenFileName() with dialog.exec() and appropriate filters to show system files

### DIFF
--- a/SnifferDialog.cpp
+++ b/SnifferDialog.cpp
@@ -194,7 +194,14 @@ SnifferDialog::onRemoveSniffer()
 void
 SnifferDialog::onBrowseSniffer()
 {
-    QString target = QFileDialog::getOpenFileName(this, "Select a sniffer device or a file");
+    QFileDialog dialog(this);
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    dialog.setFilter(QDir::System | QDir::AllEntries);
+    QString target;
+    if (dialog.exec()) {
+        QStringList selectedFiles = dialog.selectedFiles();
+        target = selectedFiles.at(0);
+    }
 
     if(target.isEmpty())
         return;


### PR DESCRIPTION
This PR replaces the call to QFileDialog::getOpenFileName() with dialog.exec().
This way we have more control over the filters that are applied to the QFileDialog.

See #1 
