### PR TITLE
switch to Qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This is the GUI project of the lowpan diagnosis tool. It use the analyser module to gather informations about WSN through a sniffer (using the capture module)
 
 Use this command to generate Makefiles in the current directory:
-    qmake-qt4 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
+    qmake-qt5 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
 
 Then use
     make debug

--- a/SimpleTreeModel.cpp
+++ b/SimpleTreeModel.cpp
@@ -45,7 +45,7 @@
      models.
  */
 
- #include <QtGui>
+ #include <QtWidgets>
 
  #include "SimpleTreeItem.h"
  #include "SimpleTreeModel.h"

--- a/foren6.pro
+++ b/foren6.pro
@@ -30,7 +30,7 @@
 # Project created by QtCreator 2013-06-26T14:10:10
 #
 # Use this command to generate Makefiles in the current directory:
-#  qmake-qt4 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
+#  qmake-qt5 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
 #
 # Then use 'make debug' or 'make release' to compile the project.
 # The default target is debug (unless you didn't specified CONFIG+=debug to qmake when generating Makefiles)
@@ -39,7 +39,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui widgets
 CONFIG   += debug_and_release debug_and_release_target
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets


### PR DESCRIPTION
Qt4 was dropped from most distributions, switch to Qt5 so this still compiles on e.g. current Ubuntu

following the guide from https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5