### PR TITLE
allow non-device target string (for URI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This is the GUI project of the lowpan diagnosis tool. It use the analyser module to gather informations about WSN through a sniffer (using the capture module)
 
 Use this command to generate Makefiles in the current directory:
-    qmake-qt4 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
+    qmake-qt5 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
 
 Then use
     make debug

--- a/SimpleTreeModel.cpp
+++ b/SimpleTreeModel.cpp
@@ -45,7 +45,7 @@
      models.
  */
 
- #include <QtGui>
+ #include <QtWidgets>
 
  #include "SimpleTreeItem.h"
  #include "SimpleTreeModel.h"

--- a/SnifferDialog.cpp
+++ b/SnifferDialog.cpp
@@ -177,6 +177,10 @@ SnifferDialog::doAddSniffer(QUrl snifferUrl)
         return;
     }
 
+    if (interface->parameters & INTERFACE_TARGET) {
+        interfacePath = snifferUrl.authority();
+    }
+
     sniffer_handle = interface->open(interfacePath.toLatin1().constData(), interfaceChannel, interfaceBaudrate);
 
     if(sniffer_handle == 0) {
@@ -243,7 +247,7 @@ SnifferDialog::onSelectType(const QString & text)
 {
   int index = ui->typeCombo->findText(text);
   interface_t *interface = (interface_t *) ui->typeCombo->itemData(index).value < void *>();
-  ui->targetEdit->setEnabled((interface->parameters & INTERFACE_DEVICE) != 0);
+  ui->targetEdit->setEnabled((interface->parameters & (INTERFACE_TARGET | INTERFACE_DEVICE)) != 0);
   ui->browseButton->setEnabled((interface->parameters & INTERFACE_DEVICE) != 0);
   ui->channelSpin->setEnabled((interface->parameters & INTERFACE_CHANNEL) != 0);
   ui->baudrateCombo->setEnabled((interface->parameters & INTERFACE_BAUDRATE) != 0);

--- a/foren6.pro
+++ b/foren6.pro
@@ -30,7 +30,7 @@
 # Project created by QtCreator 2013-06-26T14:10:10
 #
 # Use this command to generate Makefiles in the current directory:
-#  qmake-qt4 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
+#  qmake-qt5 /home/am/git/lowpan-diagnosis-tool/gui-qt/rpl_diagnosis_tool.pro -r -spec linux-g++ CONFIG+=debug
 #
 # Then use 'make debug' or 'make release' to compile the project.
 # The default target is debug (unless you didn't specified CONFIG+=debug to qmake when generating Makefiles)
@@ -39,7 +39,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui widgets
 CONFIG   += debug_and_release debug_and_release_target
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets


### PR DESCRIPTION
This allows for the target field to be used for other things than device paths.
The use case is that for the ZEP sniffer interface (https://github.com/cetic/foren6-capture/pull/2) I want to be able to specify a hostname / address of the ZEP dispatcher instead of selecting a device.

This re-uses the text field for this so we don't have to introduce a new UI element. 

This PR currently includes #7 as my distribution does not provide packets for Qt4 anymore. 